### PR TITLE
removed unnecessary slash in Jenkins description

### DIFF
--- a/src/main/java/org/sonar/plugins/buildstability/BuildStabilityPlugin.java
+++ b/src/main/java/org/sonar/plugins/buildstability/BuildStabilityPlugin.java
@@ -45,7 +45,7 @@ import java.util.List;
     defaultValue = "",
     name = "Continuous Integration Server URL",
     description = "URL of the project on the CI server. Leave blank to take this value from <i>pom.xml</i>. Examples: <ul>" +
-      "<li>\"Jenkins:https://ci.jenkins-ci.org/job/jenkins_main_trunk/\"</li>" +
+      "<li>\"Jenkins:https://ci.jenkins-ci.org/job/jenkins_main_trunk\"</li>" +
       "<li>\"Bamboo:http://ci.codehaus.org/browse/SONAR\"</li></ul>",
     global = false,
     project = true,


### PR DESCRIPTION
This slash is not needed. Settings with a slash don't work.